### PR TITLE
fix: harden proxy failure handling and CI tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,8 @@ coverage
 .vscode
 js_tests
 tests
-tools
+tools/*
+!tools/healthcheck.js
 *.md
 Dockerfile
 docker-compose.yml

--- a/.github/badges/javascript.json
+++ b/.github/badges/javascript.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "JavaScript",
-  "message": "99.34%",
-  "color": "f1e05a"
-}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: Steem Load Balancer CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:
@@ -36,15 +36,19 @@ jobs:
 
   compatibility:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 26]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Set up Node.js 22
+      - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ name: Test Coverage
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -51,5 +51,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
-          path: coverage/
+          path: |
+            coverage/coverage-summary.json
+            coverage/coverage-final.json
           retention-days: 7

--- a/.github/workflows/language-badge.yaml
+++ b/.github/workflows/language-badge.yaml
@@ -1,6 +1,8 @@
 name: Update Language Badge
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: "23 5 * * 1"
   workflow_dispatch: {}
@@ -19,6 +21,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Prepare badge branch
+        run: |
+          if git ls-remote --exit-code --heads origin badges > /dev/null 2>&1; then
+            git fetch origin badges
+            git switch --force-create badges origin/badges
+          else
+            git switch --orphan badges
+          fi
+          mkdir -p .github/badges
 
       - name: Calculate JavaScript percentage
         env:
@@ -46,11 +60,11 @@ jobs:
 
       - name: Commit changed badge
         run: |
-          if git diff --quiet -- .github/badges/javascript.json; then
+          git add .github/badges/javascript.json
+          if git diff --cached --quiet; then
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/badges/javascript.json
           git commit -m "Update JavaScript percentage badge [skip ci]"
-          git push
+          git push origin HEAD:badges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ project follows [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Compatibility CI for the Node.js version used by the production image.
+
+### Changed
+
+- Publish the dynamic JavaScript badge from a dedicated `badges` branch.
+- Honor `logging: false` across routine startup, health-check, routing, retry,
+  and request-body logs.
+- Limit coverage workflow artifacts to the JSON data required for pull request
+  comments.
+
+### Fixed
+
+- Include the configured health-check probe in production Docker images.
+- Preserve upstream GET status codes in response metadata and count upstream
+  5xx responses as circuit-breaker failures.
+
 ## 1.1.0 - 2026-07-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,73 +1,46 @@
-# Contributing to This Project
+# Contributing to Steem Load Balancer
 
-Thank you for considering contributing to this project! We welcome contributions of all kinds, including bug fixes, new features, and improvements to the documentation.
+Bug fixes, focused features, tests, and documentation improvements are welcome.
 
-## Getting Started
+## Prerequisites
 
-1. **Fork the Repository:**
-   - Click the "Fork" button at the top right of the repository page.
-2. **Clone Your Fork:**
-   ```bash
-   git clone https://github.com/<your-username>/steem-load-balancer.git
-   cd steem-load-balancer
-   ```
-3. **Install Dependencies:**
-   ```bash
-   npm ci
-   ```
+- Node.js 22 or newer. Node.js 24 is the recommended development version in `.nvmrc`.
+- npm, included with Node.js.
+- Docker and Docker Compose when changing container or integration behavior.
+
+## Local Setup
+
+```bash
+git clone https://github.com/<your-username>/steem-load-balancer.git
+cd steem-load-balancer
+nvm use
+npm ci
+```
+
+Create a focused branch from the latest `main`:
+
+```bash
+git checkout -b fix/short-description
+```
 
 ## Making Changes
 
-1. **Create a Branch:**
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-2. **Make Your Changes:**
-   - Run the linter to ensure code quality:
-     ```bash
-     npm run lint
-     ## Auto-fix lint issues where possible
-     npm run lint:fix
-     ```
-   - Check formatting (and auto-fix) with Prettier:
-     ```bash
-     npm run format
-     ## Fix the coding style automatically
-     npm run format:fix
-     ```
-    - Add or update focused tests and make sure they pass:
-     ```bash
-     npm run coverage
-     ```
-    - Run the complete local validation (lint, format, coverage, build, and
-     dependency audit):
-     ```bash
-     npm run check
-     ```
-3. **Commit Your Changes:**
-   ```bash
-   git add .
-   git commit -m "Add your meaningful commit message"
-   ```
-4. **Push to Your Fork:**
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+- Follow the existing ESM and formatting conventions.
+- Add or update focused tests for behavior changes.
+- Update `README.md` and `config.yaml` when configuration or public behavior changes.
+- Do not commit credentials, private headers, certificates, or `.env` files.
 
-## Submitting Your Contribution
+Run the narrowest relevant test while developing, then run the complete local gate before pushing:
 
-1. **Create a Pull Request:**
-   - Go to the original repository and click the "New Pull Request" button.
-   - Select your fork and branch as the source and submit the pull request.
-2. **Review Process:**
-   - The maintainers will review your changes and may request additional changes.
+```bash
+npm test -- js_tests/app.test.js
+npm run check
+```
 
-## Code of Conduct
+Use `npm run test:integration` when changing startup, Docker, networking, or configuration behavior.
 
-By contributing, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+## Pull Requests
 
-## Questions or Help?
+Keep pull requests scoped and explain the user-visible behavior, motivation, and test evidence. Complete the pull request checklist and link any related issue. CI must pass on all supported Node.js versions before merge.
 
-If you have any questions or need help, feel free to open an issue or reach out in the discussions.
-
-Happy coding! 🚀
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md). Report vulnerabilities privately according to the [Security Policy](SECURITY.md); use GitHub Issues or Discussions for other questions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use the current Node.js LTS major on Alpine for a small, stable base.
+# Use the production Node.js major on Alpine for a small, stable base.
 FROM node:26-alpine
 
 # Set working directory

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Steem Load Balancer
 [![CI](https://github.com/DoctorLai/steem-load-balancer/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/DoctorLai/steem-load-balancer/actions/workflows/ci.yaml)
-[![Coverage](https://github.com/DoctorLai/steem-load-balancer/actions/workflows/coverage.yaml/badge.svg?branch=main)](https://github.com/DoctorLai/steem-load-balancer/actions/workflows/coverage.yaml)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22-43853d?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 [![Code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?logo=prettier&logoColor=white)](https://prettier.io)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Privacy: no telemetry](https://img.shields.io/badge/privacy-no_telemetry-2ea44f.svg)](PRIVACY.md)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/DoctorLai/steem-load-balancer)
 
-[![JavaScript](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FDoctorLai%2Fsteem-load-balancer%2Fmain%2F.github%2Fbadges%2Fjavascript.json)](https://github.com/DoctorLai/steem-load-balancer)
+[![JavaScript](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FDoctorLai%2Fsteem-load-balancer%2Fbadges%2F.github%2Fbadges%2Fjavascript.json)](https://github.com/DoctorLai/steem-load-balancer)
 [![Top language](https://img.shields.io/github/languages/top/DoctorLai/steem-load-balancer)](https://github.com/DoctorLai/steem-load-balancer)
 [![Repo size](https://img.shields.io/github/repo-size/DoctorLai/steem-load-balancer)](https://github.com/DoctorLai/steem-load-balancer)
 [![Last commit](https://img.shields.io/github/last-commit/DoctorLai/steem-load-balancer)](https://github.com/DoctorLai/steem-load-balancer/commits/main)
@@ -47,7 +47,7 @@ Please note that this can be easily configured to work with other Blockchains su
 - Circuit Breaker: Automatically ejects a node after repeated forwarding failures and re-admits it after a cooldown, with automatic fail-open so routing never stalls.
 - Health, Version & Metrics Endpoints: Lightweight `/health` and `/version` endpoints plus a Prometheus `/metrics` scrape endpoint (see [API Endpoints](#api-endpoints)).
 - Rate Limiting: Protects against abuse by limiting the number of requests. For example, maximum 600 requests per 10 second window. This can be set in the [config.yaml](./config.yaml).
-- Logging: Provides detailed logs for debugging and monitoring.
+- Configurable Logging: Provides detailed operational logs when enabled and can be disabled for privacy-sensitive deployments.
 - SSL Support: Configurable SSL certificates for secure HTTPS communication. Reject or Ignore the SSL certificates when forwarding the requests via the field `rejectUnauthorized` in [config.yaml](./config.yaml)
 
 ## How It Works?
@@ -136,14 +136,14 @@ circuitBreaker:
 - maxRequests: Maximum number of requests allowed in the time window.
 - version: The version of the Steem Load Balancer.
 - max_age: Cache duration for responses in seconds (GET).
-- logging: Boolean value to enable or disable logging.
+- logging: Set to `false` to suppress routine application, health-check, retry, and request-body logs. Fatal startup and server lifecycle messages are still emitted.
 - sslCertPath: Path to the SSL certificate file for HTTPS communication.
 - sslKeyPath: Path to the SSL key file for HTTPS communication.
 - user_agent: User Agent String in the Header to forward.
 - min_blockchain_version: Min blockchain version number e.g. 0.23.0 to decide the validity of a node.
 - max_payload_size: Max payload size.
 - max_jussi_number_diff: The maximum difference of block difference is allowed.
-- logging_max_body_len: truncate the request.body in log.
+- logging_max_body_len: Maximum number of request-body characters included in logs.
 - retry_count: Retry count for GET and POST forward requests. There is a 100ms between retries.
 - rejectUnauthorized: Should we ignore SSL errors? Default true.
 - timeout: Max timeout (milliseconds) for fetch to time out.
@@ -162,7 +162,7 @@ circuitBreaker:
 - weights: Optional map of node URL to numeric weight, used by the `weighted` strategy and weighted routing. Higher weight receives more traffic; set a weight to `0` to drain a node.
 - weighted_routing: When `true`, the order nodes are probed is biased by their `weights` even if `strategy` is not `weighted`. This mainly matters when `plimit` is smaller than the number of nodes (otherwise all nodes are probed concurrently and the `weighted` selection strategy does the real biasing). Default `false`; the `weighted` strategy enables it automatically.
 - sticky: When `true`, all clients share the same chosen upstream node for the cache TTL (minimises node churn). When `false` (default) each client IP sticks to its own node.
-- circuitBreaker.enabled: Enable the per-node circuit breaker. Enabled by default; it "fails open" (re-admits every node if they would all be ejected) so it never stalls routing.
+- circuitBreaker.enabled: Enable the per-node circuit breaker. The code default is `false`; the shipped [config.yaml](./config.yaml) enables it. It "fails open" (re-admits every node if they would all be ejected) so it never stalls routing.
 - circuitBreaker.failureThreshold: Consecutive forwarding failures before a node is ejected. Default `5`.
 - circuitBreaker.cooldownMs: How long (ms) an ejected node stays out before a trial request is allowed. Default `30000`.
 - headers: The headers can be specified to pass to the downstream nodes. When proxying requests, the Load Balancer injects a shared-secret header so downstream nodes can identify trusted traffic and apply elevated (or exempt) rate-limit policies.
@@ -329,10 +329,14 @@ Use [integration-tests-docker-compose.sh](./tests/integration-tests-docker-compo
 Run `npm test` or `npm run test` to run the unit tests on the project.
 
 ## Test Coverage
-Run `npm run coverage` to run the tests with a coverage report.
+Run `npm run coverage` to generate a local report and enforce these global minimums:
+
+| Statements | Branches | Functions | Lines |
+| ---------- | -------- | --------- | ----- |
+| 85% | 80% | 88% | 85% |
 
 ## Development
-Install dependencies with `npm install`, then use the scripts below. Run `npm run check` before pushing - it mirrors the CI pipeline.
+Install dependencies with `npm ci`, then use the scripts below. Run `npm run check` before pushing - it mirrors the CI pipeline.
 
 | Script | Description |
 | ------ | ----------- |
@@ -353,7 +357,7 @@ Install dependencies with `npm install`, then use the scripts below. Run `npm ru
 | `npm run ci` | Run the complete CI validation (`npm run check`). |
 
 ```bash
-npm install
+npm ci
 npm run check
 ```
 
@@ -372,7 +376,7 @@ If you have SSL certificates, provide the paths in the [config.yaml](./config.ya
 The rate limiting configuration prevents abuse by restricting the number of requests a user can make within a given time window. Adjust the rateLimit settings in [config.yaml](./config.yaml) as needed.
 
 ## Logging
-Enable logging by setting "logging": true in [config.yaml](./config.yaml). Logs will be printed to the console and can help with debugging and monitoring.
+Routine logging is enabled unless `logging` is set to `false` in [config.yaml](./config.yaml). When enabled, POST request bodies are truncated to `logging_max_body_len` characters but may still contain sensitive data; disable logging when request content should not be recorded.
 
 ## Statistics
 On the GET requests, the response JSON will show some additional data including statistics (including Uptime, Access Counters, Error Counters, Not Chosen Counters and Jussi Behind Counters):

--- a/js_tests/app.test.js
+++ b/js_tests/app.test.js
@@ -9,6 +9,10 @@ const passthroughLimit = async () => (fn) => fn();
 
 const noopLog = () => {};
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 function healthyNode(server) {
   return {
     server,
@@ -76,9 +80,12 @@ describe("createApp operational endpoints", () => {
 
 describe("createApp proxying", () => {
   test("GET / forwards and augments the response", async () => {
-    const app = makeApp(baseConfig());
+    const app = makeApp(baseConfig({ max_age: 60 }), {
+      startTime: new Date(Date.now() - 2000),
+    });
     const res = await request(app).get("/");
     expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("max-age=60");
     expect(res.body.status).toBe("OK");
     expect(res.body.status_code).toBe(200);
     expect(res.body.__load_balancer_version__).toBe("test-1.0.0");
@@ -89,6 +96,8 @@ describe("createApp proxying", () => {
       strategy: "max_jussi_number",
       circuit_breaker_enabled: false,
     });
+    expect(res.body.__stats__.seconds).toBeGreaterThanOrEqual(1);
+    expect(res.body.__stats__.rps).toBeGreaterThan(0);
   });
 
   test("POST / forwards the JSON-RPC body", async () => {
@@ -100,6 +109,28 @@ describe("createApp proxying", () => {
     });
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ jsonrpc: "2.0", result: 42, id: 1 });
+  });
+
+  test("logging false suppresses request and forwarding logs", async () => {
+    const log = jest.fn();
+    const forwardPOST = jest.fn(async (server, body, options) => {
+      options.logger(`POST ${server} body=${body}`);
+      return {
+        statusCode: 200,
+        data: JSON.stringify({ jsonrpc: "2.0", result: 42, id: 1 }),
+      };
+    });
+    const app = makeApp(baseConfig({ logging: false }), { log, forwardPOST });
+
+    const res = await request(app).post("/").send({
+      jsonrpc: "2.0",
+      method: "condenser_api.get_account_count",
+      id: 1,
+    });
+
+    expect(res.status).toBe(200);
+    expect(forwardPOST).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
   });
 
   test("unsupported methods return 405", async () => {
@@ -132,6 +163,46 @@ describe("createApp proxying", () => {
     expect(res.body).toEqual({ error: "Failed to choose node" });
   });
 
+  test("returns non-JSON upstream responses without discarding the payload", async () => {
+    const app = makeApp(baseConfig(), {
+      forwardGET: async () => ({ statusCode: 202, data: "still processing" }),
+    });
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(202);
+    expect(res.body).toMatchObject({
+      raw: "still processing",
+      warning: "Upstream did not return JSON",
+      status_code: 202,
+    });
+  });
+
+  test("preserves upstream 5xx status and records a breaker failure", async () => {
+    const circuitBreaker = new CircuitBreaker({
+      enabled: true,
+      failureThreshold: 1,
+      cooldownMs: 60000,
+      now: () => 0,
+    });
+    const app = makeApp(baseConfig({ nodes: ["https://only.example"] }), {
+      circuitBreaker,
+      forwardGET: async () => ({
+        statusCode: 503,
+        data: JSON.stringify({ error: "upstream unavailable" }),
+      }),
+    });
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status_code).toBe(503);
+    expect(circuitBreaker.getState()["https://only.example"]).toEqual({
+      failures: 1,
+      open: true,
+    });
+  });
+
   test("returns 500 when the chosen node is missing required fields", async () => {
     const app = makeApp(baseConfig(), {
       getServerData: async (node) => ({ server: node }), // no version/jussi_number
@@ -139,6 +210,28 @@ describe("createApp proxying", () => {
     const res = await request(app).get("/");
     expect(res.status).toBe(500);
     expect(res.body.error).toMatch(/No valid node found/);
+  });
+
+  test("returns 500 when the forwarding result has no status code", async () => {
+    const circuitBreaker = new CircuitBreaker({
+      enabled: true,
+      failureThreshold: 1,
+      cooldownMs: 60000,
+      now: () => 0,
+    });
+    const app = makeApp(baseConfig(), {
+      circuitBreaker,
+      forwardGET: async () => ({ data: JSON.stringify({ status: "OK" }) }),
+    });
+
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(500);
+    expect(res.body.status).toBe("OK");
+    expect(circuitBreaker.getState()[res.body.__server__]).toEqual({
+      failures: 1,
+      open: true,
+    });
   });
 });
 
@@ -150,16 +243,20 @@ describe("createApp circuit breaker integration", () => {
       cooldownMs: 60000,
       now: () => 0,
     });
-    const app = makeApp(baseConfig({ nodes: ["https://only.example"] }), {
-      circuitBreaker,
-      forwardGET: async () => {
-        throw new Error("upstream exploded");
+    const app = makeApp(
+      baseConfig({ nodes: ["https://only.example"], debug: true }),
+      {
+        circuitBreaker,
+        forwardGET: async () => {
+          throw new Error("upstream exploded");
+        },
       },
-    });
+    );
 
     const proxied = await request(app).get("/");
     // Single node fails open, so the request still returns (with a 500 payload).
     expect(proxied.body.status_code).toBe(500);
+    expect(proxied.headers.error).toBe("{}");
 
     const health = await request(app).get("/health");
     expect(health.body.circuit_breaker["https://only.example"]).toEqual({
@@ -187,6 +284,7 @@ describe("createApp circuit breaker integration", () => {
   });
 
   test("does not reuse a cached node while its circuit is open", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.999);
     const circuitBreaker = new CircuitBreaker({
       enabled: true,
       failureThreshold: 1,
@@ -216,11 +314,25 @@ describe("createApp circuit breaker integration", () => {
 
     expect(res.body.__server__).toBe("https://next.example");
   });
+
+  test("reuses a healthy cached node without probing again", async () => {
+    const getServerData = jest.fn(async (node) => healthyNode(node));
+    const app = makeApp(baseConfig({ cache: { enabled: true, ttl: 60 } }), {
+      getServerData,
+    });
+
+    const first = await request(app).get("/");
+    const probeCount = getServerData.mock.calls.length;
+    const second = await request(app).get("/");
+
+    expect(second.body.__server__).toBe(first.body.__server__);
+    expect(getServerData).toHaveBeenCalledTimes(probeCount);
+  });
 });
 
 describe("createApp weighted routing", () => {
   test("uses the weighted strategy when configured", async () => {
-    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0);
+    jest.spyOn(Math, "random").mockReturnValue(0);
     const app = makeApp(
       baseConfig({
         nodes: ["https://a.example", "https://b.example"],
@@ -232,6 +344,5 @@ describe("createApp weighted routing", () => {
     const res = await request(app).get("/");
     expect(res.status).toBe(200);
     expect(res.body.__config__.weighted_routing).toBe(true);
-    randomSpy.mockRestore();
   });
 });

--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,6 @@ import { StatusCodes } from "http-status-codes";
 import {
   shuffle,
   log as defaultLog,
-  limitStringMaxLength,
   secondsToTimeDict,
   isObjectEmptyOrNullOrUndefined,
 } from "./functions.js";
@@ -51,6 +50,7 @@ function createApp(config, deps = {}) {
     createLimit,
     log = defaultLog,
   } = deps;
+  const logger = config.logging === false ? () => {} : log;
 
   // Derived configuration.
   const timeout = config.timeout ?? 3000;
@@ -95,6 +95,7 @@ function createApp(config, deps = {}) {
       minBlockchainVersion: min_blockchain_version,
       maxJussiNumberDiff: max_jussi_number_diff,
       counters,
+      logger,
     });
 
   const resolvedCreateLimit =
@@ -165,7 +166,7 @@ function createApp(config, deps = {}) {
 
   app.use((err, req, res, next) => {
     if (err instanceof SyntaxError && err.status === 400 && "body" in err) {
-      log(`Invalid JSON received from ${req.ip}`);
+      logger(`Invalid JSON received from ${req.ip}`);
       return res.status(400).json({ error: "Invalid JSON" });
     }
     next(err);
@@ -209,10 +210,10 @@ function createApp(config, deps = {}) {
       const cachedNode = cacheLastNode.get(cacheKey);
       if (Date.now() - cachedNode.timestamp < cacheMaxAge * 1000) {
         if (circuitBreaker.isOpen(cachedNode.server)) {
-          log(`Cached node is circuit-open, skipping: ${cachedNode.server}`);
+          logger(`Cached node is circuit-open, skipping: ${cachedNode.server}`);
           cacheLastNode.delete(cacheKey);
         } else {
-          log(`Using cached node: ${cachedNode.server}`);
+          logger(`Using cached node: ${cachedNode.server}`);
           chosenNode = cachedNode;
         }
       }
@@ -226,7 +227,7 @@ function createApp(config, deps = {}) {
 
       const result = await chooseNodeFn(promises, firstK, strategy).catch(
         (error) => {
-          log(`Error: ${error.message}`);
+          logger(`Error: ${error.message}`);
           return null;
         },
       );
@@ -250,7 +251,7 @@ function createApp(config, deps = {}) {
         });
         return;
       }
-      log(
+      logger(
         `Chosen Node: ${chosenNode.server} with jussi_number ${chosenNode.jussi_number}`,
       );
       chosenNode.timestamp = Date.now();
@@ -261,7 +262,7 @@ function createApp(config, deps = {}) {
       }
     }
 
-    log(`Current Max Jussi: ${counters.maxJussi}`);
+    logger(`Current Max Jussi: ${counters.maxJussi}`);
     res.setHeader("IP", ip);
     res.setHeader("Server", chosenNode.server);
     if (typeof chosenNode.version !== "undefined") {
@@ -291,12 +292,10 @@ function createApp(config, deps = {}) {
           retry_count,
           user_agent,
           headers: config.headers?.[chosenNode.server] || {},
+          logger,
         });
       } else if (method === "POST") {
         const body = JSON.stringify(req.body);
-        log(
-          `Request Body is ${limitStringMaxLength(body, logging_max_body_len)}`,
-        );
         result = await forwardPOST(chosenNode.server, body, {
           agent,
           timeout,
@@ -304,6 +303,7 @@ function createApp(config, deps = {}) {
           user_agent,
           logging_max_body_len,
           headers: config.headers?.[chosenNode.server] || {},
+          logger,
         });
       }
       try {
@@ -315,10 +315,16 @@ function createApp(config, deps = {}) {
         };
       }
       if (method === "GET") {
-        data["status_code"] = 200;
+        data["status_code"] = result.statusCode;
       }
-      // Successful forward: reset the node's circuit breaker.
-      circuitBreaker.recordSuccess(chosenNode.server);
+      if (
+        isObjectEmptyOrNullOrUndefined(result.statusCode) ||
+        result.statusCode >= 500
+      ) {
+        circuitBreaker.recordFailure(chosenNode.server);
+      } else {
+        circuitBreaker.recordSuccess(chosenNode.server);
+      }
     } catch (ex) {
       data = {
         status_code: 500,
@@ -328,7 +334,7 @@ function createApp(config, deps = {}) {
       if (config.debug === true) {
         res.setHeader("Error", JSON.stringify(ex));
       }
-      log(`Error forwarding request to ${chosenNode.server}: ${ex.message}`);
+      logger(`Error forwarding request to ${chosenNode.server}: ${ex.message}`);
       await counters.incrementError(chosenNode.server);
       // Failed forward (after retries): trip the node's circuit breaker.
       circuitBreaker.recordFailure(chosenNode.server);

--- a/src/health-check.js
+++ b/src/health-check.js
@@ -17,6 +17,7 @@ function createGetServerData({
   minBlockchainVersion,
   maxJussiNumberDiff,
   counters,
+  logger = log,
 }) {
   // Fetch version from the server
   return async function getServerData(server) {
@@ -67,20 +68,20 @@ function createGetServerData({
       ] = await Promise.all([versionPromise, jussiPromise]);
 
       const latencyMs = performance.now() - startTime; // end timer
-      log(
+      logger(
         `Server ${server} Latency: ${latencyMs.toFixed(2)} ms (version: ${versionLatency} ms, jussi: ${jussiLatency} ms)`,
       );
 
       if (!versionResponse.ok) {
         let err_msg = `Server ${server} (version) responded with status: ${versionResponse.status}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
 
       if (!jussiResponse.ok) {
         let err_msg = `Server ${server} (jussi_number) responded with status: ${jussiResponse.status}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
@@ -92,7 +93,7 @@ function createGetServerData({
         isObjectEmptyOrNullOrUndefined(jsonResponse["result"])
       ) {
         let err_msg = `Server ${server} Invalid version response: ${JSON.stringify(jsonResponse)}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
@@ -100,7 +101,7 @@ function createGetServerData({
       const blockchain_version = jsonResponse["result"]["blockchain_version"];
       if (compareVersion(blockchain_version, minBlockchainVersion) == -1) {
         let err_msg = `Server ${server} version = ${blockchain_version}: but min version is ${minBlockchainVersion}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
@@ -108,19 +109,19 @@ function createGetServerData({
       const jussi = await jussiResponse.json();
       if (isObjectEmptyOrNullOrUndefined(jussi)) {
         let err_msg = `Server ${server} Invalid jussi response: ${JSON.stringify(jussi)}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
       if (jussi["status"] !== "OK") {
         let err_msg = `Server ${server} Jussi Status != "OK": ${JSON.stringify(jussi)}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementNotChosen(server);
         throw new Error(err_msg);
       }
       let jussi_number = jussi["jussi_num"];
 
-      log(`Server ${server} jussi_number: ${jussi_number}`);
+      logger(`Server ${server} jussi_number: ${jussi_number}`);
       if (typeof jussi_number === "number" && Number.isInteger(jussi_number)) {
         jussi_number = parseInt(jussi_number);
       }
@@ -135,21 +136,21 @@ function createGetServerData({
 
       if (counters.maxJussi > jussi_number + maxJussiNumberDiff) {
         let err_msg = `Server ${server} is too far behind: jussi_number ${jussi_number} vs latest ${counters.maxJussi} - diff ${counters.maxJussi - jussi_number}`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementJussiBehind(server);
         throw new Error(err_msg);
       }
 
-      log(
+      logger(
         `Tested OK: Server ${server} version=${blockchain_version}, jussi_number=${jussi_number}`,
       );
       return { server, version: jsonResponse, jussi_number, latencyMs };
     } catch (error) {
       let err_msg = `${error.name}: Server ${server} Failed to fetch version from ${server}: ${error.message}`;
-      log(err_msg);
+      logger(err_msg);
       if (error.name === "AbortError" || error.message.includes("timed out")) {
         err_msg = `Fetch request to ${server} timed out after ${timeout} ms`;
-        log(err_msg);
+        logger(err_msg);
         await counters.incrementTimedOut(server);
       }
       throw new Error(err_msg, { cause: error });

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const startTime = new Date();
-log(`Current Time: ${startTime.toISOString()}`);
 
 // Read the YAML config file located one level up from the current directory.
 // Validation is intentionally disabled here so the process can emit its own
@@ -22,6 +21,8 @@ log(`Current Time: ${startTime.toISOString()}`);
 // gracefully, matching the documented start-up behaviour.
 const configPath = path.join(__dirname, "../config.yaml");
 const config = loadConfig(configPath, { validate: false });
+const logger = config.logging === false ? () => {} : log;
+logger(`Current Time: ${startTime.toISOString()}`);
 
 // Extract configuration values and fail fast on an empty node list.
 const nodes = config.nodes ?? [];
@@ -32,20 +33,20 @@ if (!Array.isArray(nodes) || nodes.length === 0) {
 
 // Log the effective runtime configuration.
 const PORT = config.port ?? 9091;
-log(`PLimit: ${config.plimit}`);
-log(`Reject Unauthorized: ${config.rejectUnauthorized ?? true}`);
-log(`Timeout: ${config.timeout ?? 3000}`);
-log(`FirstK: ${config.firstK ?? 1}`);
-log(`Node Strategy: ${config.strategy ?? "max_jussi_number"}`);
-log(`Cache Enabled: ${config.cache?.enabled ?? false}`);
-log(
+logger(`PLimit: ${config.plimit}`);
+logger(`Reject Unauthorized: ${config.rejectUnauthorized ?? true}`);
+logger(`Timeout: ${config.timeout ?? 3000}`);
+logger(`FirstK: ${config.firstK ?? 1}`);
+logger(`Node Strategy: ${config.strategy ?? "max_jussi_number"}`);
+logger(`Cache Enabled: ${config.cache?.enabled ?? false}`);
+logger(
   `Sticky Routing: ${config.sticky === true || config.cache?.sticky === true}`,
 );
-log(`Circuit Breaker Enabled: ${config.circuitBreaker?.enabled ?? false}`);
-log(`Max Payload Size = ${config.max_payload_size}`);
-log(`Version: ${config.version ?? "NA"}`);
-log(`Listening on Port: ${PORT}`);
-log(`Nodes: ${config.nodes}`);
+logger(`Circuit Breaker Enabled: ${config.circuitBreaker?.enabled ?? false}`);
+logger(`Max Payload Size = ${config.max_payload_size}`);
+logger(`Version: ${config.version ?? "NA"}`);
+logger(`Listening on Port: ${PORT}`);
+logger(`Nodes: ${config.nodes}`);
 
 const counters = new Counters();
 const circuitBreaker = new CircuitBreaker(config.circuitBreaker ?? {});
@@ -61,8 +62,8 @@ let server;
 // Determine if SSL certificates exist
 const sslCertPath = config.sslCertPath;
 const sslKeyPath = config.sslKeyPath;
-log(`sslCertPath = ${sslCertPath}`);
-log(`sslKeyPath = ${sslKeyPath}`);
+logger(`sslCertPath = ${sslCertPath}`);
+logger(`sslKeyPath = ${sslKeyPath}`);
 
 if (fs.existsSync(sslCertPath) && fs.existsSync(sslKeyPath)) {
   // SSL certificates are available; create HTTPS server

--- a/src/network.js
+++ b/src/network.js
@@ -32,14 +32,14 @@ async function fetchWithTimeout(url, options = {}, timeout = 5000) {
 // Forward GET request to the chosen node
 async function forwardRequestGET(
   apiURL,
-  { agent, timeout, retry_count, user_agent, headers } = {},
+  { agent, timeout, retry_count, user_agent, headers, logger = log } = {},
 ) {
   // Always attempt at least once, even if retry_count is 0 or unset, so the
   // caller never receives an `undefined` result from an empty loop.
   const attempts = Math.max(1, retry_count ?? 1);
   for (let i = 0; i < attempts; ++i) {
     try {
-      log(`GET: Forwarding to ${apiURL}`);
+      logger(`GET: Forwarding to ${apiURL}`);
       const { response: res, latency } = await fetchWithTimeout(
         apiURL,
         {
@@ -57,11 +57,11 @@ async function forwardRequestGET(
         timeout,
       );
       const data = await res.text();
-      log(`Status: ${res.status} Latency: ${latency}ms`);
+      logger(`Status: ${res.status} Latency: ${latency}ms`);
       return { statusCode: res.status, data };
     } catch (error) {
       if (i < attempts - 1) {
-        log(`Retrying ${apiURL}, attempt ${i + 1}`);
+        logger(`Retrying ${apiURL}, attempt ${i + 1}`);
         await sleep(100);
         continue;
       }
@@ -81,13 +81,14 @@ async function forwardRequestPOST(
     user_agent,
     logging_max_body_len,
     headers,
+    logger = log,
   } = {},
 ) {
   // Always attempt at least once, even if retry_count is 0 or unset.
   const attempts = Math.max(1, retry_count ?? 1);
   for (let i = 0; i < attempts; ++i) {
     try {
-      log(
+      logger(
         `POST: Forwarding to ${apiURL}, body=${limitStringMaxLength(body, logging_max_body_len)}`,
       );
       const { response: res, latency } = await fetchWithTimeout(
@@ -107,12 +108,12 @@ async function forwardRequestPOST(
         },
         timeout,
       );
-      log(`Status: ${res.status} Latency: ${latency}ms`);
+      logger(`Status: ${res.status} Latency: ${latency}ms`);
       const data = await res.text();
       return { statusCode: res.status, data };
     } catch (error) {
       if (i < attempts - 1) {
-        log(`Retrying ${apiURL}, attempt ${i + 1}`);
+        logger(`Retrying ${apiURL}, attempt ${i + 1}`);
         await sleep(100);
         continue;
       }


### PR DESCRIPTION
## Summary

- Preserve upstream GET status metadata and count 5xx or malformed forwarding responses as circuit-breaker failures.
- Honor `logging: false` across startup, health checks, routing, retries, and request-body logging.
- Package the Docker healthcheck correctly and test the production Node.js 26 runtime alongside supported Node.js versions in CI.
- Publish the dynamic JavaScript badge from a dedicated `badges` branch and reduce coverage artifacts to the JSON files required for PR comments.
- Expand proxy, cache, error-response, and circuit-breaker tests, and refresh the README, changelog, and contribution guide.

## Testing

- `npm run check` (165 tests passed; 90.23% statements, 82.19% branches, 90.99% functions, 90% lines; 0 audit vulnerabilities)
- `docker build --tag steem-load-balancer:pr-review .`
- `docker run --rm --entrypoint test steem-load-balancer:pr-review -f /app/tools/healthcheck.js`
- Parsed all CI, coverage, reporting, and badge workflows with `js-yaml`
